### PR TITLE
[AI-341] - Fixes for compatibility with Adobe Commerce version 2.4.8-p1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+### 5.2.0 - 2025/08/18
+Compatibilidad con Adobe Commerce 2.4.8-p1
+* Soporte para PHP 8.2, 8.3 y 8.4 en el módulo.
+* Ajustes de compatibilidad con Monolog 3 (uso de métodos PSR-3 en logger interno).
+* Actualización de CSP: se añaden `pay.conekta.com` a `script-src`, `connect-src` y `frame-src` para el componente embebido.
+* Se actualizan constraints de desarrollo para PHPUnit 10.
+* No se requieren cambios de esquema de BD.
+
+Notas de actualización
+* Requiere ejecutar `bin/magento setup:upgrade` tras actualizar el paquete.
+* Asegúrese de tener PHP 8.3+ antes de actualizar a Adobe Commerce 2.4.8-p1, según las notas oficiales de la versión 2.4.8.
+* Si usa políticas CSP personalizadas, incluya `pay.conekta.com` en `script-src`, `connect-src` y `frame-src`.
+
 ### 5.1.9 - 2025/08/13
 * Support for paying with BNPL has been added to the embedded component
 ### 5.1.8 - 2024/11/04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 ### 5.2.0 - 2025/08/18
-Compatibilidad con Adobe Commerce 2.4.8-p1
-* Soporte para PHP 8.2, 8.3 y 8.4 en el módulo.
-* Ajustes de compatibilidad con Monolog 3 (uso de métodos PSR-3 en logger interno).
-* Actualización de CSP: se añaden `pay.conekta.com` a `script-src`, `connect-src` y `frame-src` para el componente embebido.
-* Se actualizan constraints de desarrollo para PHPUnit 10.
-* No se requieren cambios de esquema de BD.
+Compatibility with Adobe Commerce 2.4.8-p1
+- Support for PHP 8.2, 8.3, and 8.4 in the module.
+- Compatibility adjustments for Monolog 3 (using PSR-3 methods in the internal logger).
+- CSP update: `pay.conekta.com` added to `script-src`, `connect-src`, and `frame-src` for the embedded component.
+- Development constraints updated for PHPUnit 10.
+- No database schema changes required.
 
-Notas de actualización
-* Requiere ejecutar `bin/magento setup:upgrade` tras actualizar el paquete.
-* Asegúrese de tener PHP 8.3+ antes de actualizar a Adobe Commerce 2.4.8-p1, según las notas oficiales de la versión 2.4.8.
-* Si usa políticas CSP personalizadas, incluya `pay.conekta.com` en `script-src`, `connect-src` y `frame-src`.
+Upgrade notes
+- Requires running `bin/magento setup:upgrade` after updating the package.
+- Ensure you have PHP 8.3+ before upgrading to Adobe Commerce 2.4.8-p1, per the official 2.4.8 release notes.
+- If you use custom CSP policies, include `pay.conekta.com` in `script-src`, `connect-src`, and `frame-src`.
 
 ### 5.1.9 - 2025/08/13
 * Support for paying with BNPL has been added to the embedded component

--- a/Logger/Logger.php
+++ b/Logger/Logger.php
@@ -31,7 +31,34 @@ class Logger
         $conektaHelper = $objectManager->create(Data::class);
 
         if ((int)$conektaHelper->getConfigData('conekta/conekta_global', 'debug')) {
-            return $this->logger->addRecord($level, $message, $context);
+            switch ($level) {
+                case \Monolog\Logger::DEBUG:
+                    $this->logger->debug($message, $context);
+                    break;
+                case \Monolog\Logger::INFO:
+                    $this->logger->info($message, $context);
+                    break;
+                case \Monolog\Logger::WARNING:
+                    $this->logger->warning($message, $context);
+                    break;
+                case \Monolog\Logger::ERROR:
+                    $this->logger->error($message, $context);
+                    break;
+                case \Monolog\Logger::CRITICAL:
+                    $this->logger->critical($message, $context);
+                    break;
+                case \Monolog\Logger::ALERT:
+                    $this->logger->alert($message, $context);
+                    break;
+                case \Monolog\Logger::EMERGENCY:
+                    $this->logger->emergency($message, $context);
+                    break;
+                case \Monolog\Logger::NOTICE:
+                default:
+                    $this->logger->notice($message, $context);
+                    break;
+            }
+            return true;
         }
 
         return true;

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ php bin/magento module:enable conekta_payments
 bin/magento c:f
 ```
 
-Installation for Magento 2.4 (genérico)
+Installation for Magento 2.4 (generic)
 -----------
 
 1. First add this repository in your composer config

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ![alt tag](https://conekta.com/static/assets/Home/conekta-logo-blue-full.svg)
 
-Magento 2 Plugin v.5.1.9 (Stable)
+Magento 2 Plugin v.5.2.0 (Stable)
 ========================
 
-Installation for Magento 2.3
+Installation for Magento 2.4.8-p1
 -----------
 
 1. First add this repository in your composer config
@@ -13,7 +13,7 @@ composer config repositories.conekta git https://github.com/conekta/customer-mag
 
 2. Add composer dependency
 ```bash
-composer require conekta/conekta_payments 5.1.9
+composer require conekta/conekta_payments 5.2.0
 ```
 
 3. Update Magento
@@ -36,7 +36,7 @@ php bin/magento module:enable conekta_payments
 bin/magento c:f
 ```
 
-Installation for Magento 2.4
+Installation for Magento 2.4 (genérico)
 -----------
 
 1. First add this repository in your composer config
@@ -46,7 +46,7 @@ composer config repositories.conekta git https://github.com/conekta/customer-mag
 
 2. Add composer dependency
 ```bash
-composer require conekta/conekta_payments master
+composer require conekta/conekta_payments ^5.2
 ```
 
 3. Update Magento
@@ -112,7 +112,7 @@ bin/magento c:f
 
 Magento Version Compatibility
 -----------------------------
-The plugin has been tested in Magento 2.3 and 2.4 
+The plugin has been tested in Magento 2.4.8-p1, 2.4.7, 2.4.6 
 Support is not guaranteed for untested versions.
 
 

--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
     "name": "conekta/conekta_payments",
     "description": "Conekta payment gateway",
     "require": {
-        "php": ">=7.4",
+        "php": "^8.2 || ^8.3 || ^8.4",
         "conekta/conekta-php": "v6.0.8"
     },
     "type": "magento2-module",
-    "version": "5.1.9",
+    "version": "5.2.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
@@ -33,9 +33,9 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^10.5",
         "squizlabs/php_codesniffer": "^3.7",
-        "magento/framework": "^103.0",
+        "magento/framework": "^103.0 || ^104.0",
         "magento/payment-services": "*",
         "phpstan/phpstan": "1.10.32"
     }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -3,7 +3,7 @@
     <system>
         <section id="payment">
             <group id="conekta" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="0">
-                <comment><![CDATA[<div class="conekta-payment-logo"></div><div class="conekta-payment-text">Conekta Configuration. (v5.1.9) </div>]]></comment>
+                <comment><![CDATA[<div class="conekta-payment-logo"></div><div class="conekta-payment-text">Conekta Configuration. (v5.2.0) </div>]]></comment>
                 <fieldset_css>complex conekta-section</fieldset_css>
                 <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
                 <!--global-->

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -100,7 +100,7 @@
             <global>
                 <api_version><![CDATA[2.0.0]]></api_version>
                 <plugin_type><![CDATA[Magento 2]]></plugin_type>
-                <plugin_version><![CDATA[5.1.9]]></plugin_version>
+                <plugin_version><![CDATA[5.2.0]]></plugin_version>
             </global>
         </conekta>
     </default>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -5,12 +5,19 @@
         <policy id="script-src">
             <values>
                 <value id="cdn_conekta" type="host">cdn.conekta.io</value>
+                <value id="pay_conekta" type="host">pay.conekta.com</value>
                 <value id="s3_conektaapi" type="host">conektaapi.s3.amazonaws.com</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
                 <value id="s3_conektaapi" type="host">api.conekta.io</value>
+                <value id="pay_conekta_connect" type="host">pay.conekta.com</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="pay_conekta_frame" type="host">pay.conekta.com</value>
             </values>
         </policy>
     </policies>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Conekta_Payments" setup_version="5.1.9">
+    <module name="Conekta_Payments" setup_version="5.2.0">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
## Added compatibility of this Conekta Plugin for Magento.

<img width="697" height="996" alt="image" src="https://github.com/user-attachments/assets/b304389d-e576-4d13-b9a4-7cf9ff49f4a1" />


### Summary: Compatibility update for Adobe Commerce version 2.4.8-p1.